### PR TITLE
Golang 1.21.12

### DIFF
--- a/.github/workflows/abi_bindings_checker.yml
+++ b/.github/workflows/abi_bindings_checker.yml
@@ -22,12 +22,11 @@ jobs:
       - name: Set Go version
         run: |
           source ./scripts/versions.sh
-          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Install Foundry
         run: ./scripts/install_foundry.sh

--- a/.github/workflows/abi_bindings_checker.yml
+++ b/.github/workflows/abi_bindings_checker.yml
@@ -19,10 +19,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set Go version
-        run: |
-          source ./scripts/versions.sh
-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/gomod_check.yml
+++ b/.github/workflows/gomod_check.yml
@@ -18,9 +18,6 @@ jobs:
         with:
           submodules: recursive
 
-      - run: |
-          source ./scripts/versions.sh
-
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/gomod_check.yml
+++ b/.github/workflows/gomod_check.yml
@@ -20,11 +20,10 @@ jobs:
 
       - run: |
           source ./scripts/versions.sh
-          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - run: go mod tidy
       - run: git --no-pager diff -- go.mod go.sum # This prints the diff

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,12 +39,11 @@ jobs:
       - name: Set Go version
         run: |
           source ./scripts/versions.sh
-          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Install Foundry
         run: ./scripts/install_foundry.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set Go version
-        run: |
-          source ./scripts/versions.sh
-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/receipt-proofs-poc
 
-go 1.21.11
+go 1.21.12
 
 require (
 	github.com/ava-labs/avalanchego v1.11.1


### PR DESCRIPTION
Bump to latest 1.21 Golang release. Removes unnecessary explicit version used by actions/setup-go in favor of pulling directly from go.mod.